### PR TITLE
Remove `<` rule from default

### DIFF
--- a/lua/insx/preset/standard.lua
+++ b/lua/insx/preset/standard.lua
@@ -63,7 +63,6 @@ function standard.setup_insert_mode(config)
     ['('] = ')',
     ['['] = ']',
     ['{'] = '}',
-    ['<'] = '>',
   }) do
     -- jump_out
     insx.add(
@@ -195,7 +194,6 @@ function standard.setup_cmdline_mode(config)
     ['('] = ')',
     ['['] = ']',
     ['{'] = '}',
-    ['<'] = '>',
   }) do
     -- jump_out
     insx.add(

--- a/lua/insx/preset/standard.spec.lua
+++ b/lua/insx/preset/standard.spec.lua
@@ -42,7 +42,6 @@ describe('insx.preset.standard', function()
         ['('] = ')',
         ['['] = ']',
         ['{'] = '}',
-        ['<'] = '>',
       }) do
         -- autopairs.
         spec.assert('|', open, ('%s|%s'):format(open, close), option)


### PR DESCRIPTION
Operator `<` and `>` is usually use individually for comparison. Using it as default will be annoying when user just want to input `<` or `<<`. This PR remove it from the default preset.