### PR TITLE
fix(expand): Can't resolve maps in builtin completion mode

### DIFF
--- a/lua/insx/init.lua
+++ b/lua/insx/init.lua
@@ -108,7 +108,9 @@ local function create_context(char)
     char = char,
     data = {},
     mode = function()
-      return vim.api.nvim_get_mode().mode
+      -- i|ic|ix → i & c|cx → c
+      -- see `:h mode()`
+      return vim.api.nvim_get_mode().mode:sub(1, 1)
     end,
     row = function()
       if ctx.mode() == 'c' then

--- a/lua/insx/init.spec.lua
+++ b/lua/insx/init.spec.lua
@@ -273,6 +273,23 @@ describe('insx', function()
     end)
   end)
 
+  describe('ctx.mode', function()
+    it('ctx.mode: () => "i"', function()
+      local ctx ---@type insx.Context
+      insx.add('<CR>', {
+        action = function(ctx_)
+          ctx = ctx_
+        end,
+      })
+      Keymap.spec(function()
+        Keymap.send(Keymap.termcodes('i')):await()
+        Keymap.send({ keys = Keymap.termcodes('<CR>'), remap = true }):await()
+        vim.fn.complete(1, {})
+        assert.are.same(ctx.mode(), 'i')
+      end)
+    end)
+  end)
+
   describe('macro', function()
     it('should support macro', function()
       insx.add(


### PR DESCRIPTION
`mode()` returns values like `"i" | "ix" | "Ic"`, but it is expected only `"i"` in `insx.expand()` function.