### PR TITLE
fix: kit.get to return false

### DIFF
--- a/lua/insx/kit/init.lua
+++ b/lua/insx/kit/init.lua
@@ -203,6 +203,9 @@ function kit.get(value, path, default)
       return default
     end
   end
+  if result == false then
+    return false
+  end
   return result or default
 end
 


### PR DESCRIPTION
Hi @hrsh7th 

Thank you for the useful plugin.

My use case didn't require spacing, so I tried to disable it, but I couldn't change it even if I set it from config.
From what I've researched, it seems like the kit.get function isn't able to return false in certain cases.

I have fixed it, could you please check it?

The code below is my config
```lua
require("insx.preset.standard").setup({
  spacing = {
    enabled = false,
  },
})
```