### PR TITLE
fix(keymap-normalize): prevent breaking on nil value on `vim.keycode` for s

### DIFF
--- a/lua/insx/kit/Vim/Keymap.lua
+++ b/lua/insx/kit/Vim/Keymap.lua
@@ -26,7 +26,11 @@ end
 
 ---Normalize keycode.
 function Keymap.normalize(s)
-  return vim.fn.keytrans(vim.keycode(s))
+  if vim.keycode then
+    return vim.fn.keytrans(vim.keycode(s))
+  else
+    return s
+  end
 end
 
 ---Set callback for consuming next typeahead.


### PR DESCRIPTION
## WHAT

Add a small value check on `vim.keycode` before calling it on a value.

## WHY

This resolves : #39 